### PR TITLE
Improve relative path handling.

### DIFF
--- a/archiver/asset.py
+++ b/archiver/asset.py
@@ -8,6 +8,8 @@ class Asset():
     """
 
     def __init__(self, path, batch_root, md5=None):
+        if not batch_root.endswith('/'):
+            batch_root += '/'
         self.local_path = path
         self.md5        = md5 or self.calculate_md5()
         self.filename   = os.path.basename(self.local_path)
@@ -15,11 +17,14 @@ class Asset():
         self.directory  = os.path.dirname(self.local_path)
         self.bytes      = os.path.getsize(self.local_path)
         self.extension  = os.path.splitext(self.filename)[1].lstrip('.').upper()
-        self.relpath    = os.path.relpath(self.local_path, batch_root)
+        if self.local_path.startswith(batch_root):
+            self.relpath = self.local_path[len(batch_root):]
+        else:
+            raise Exception("local path is outside of batch root")
 
     def calculate_md5(self):
         """
-        Calclulate and return the object's md5 hash.
+        Calculate and return the object's md5 hash.
         """
         hash = hashlib.md5()
         with open(self.local_path, 'rb') as f:

--- a/archiver/asset.py
+++ b/archiver/asset.py
@@ -2,7 +2,19 @@ import hashlib
 import os
 
 
-class Asset():
+class PathOutOfScopeException(Exception):
+    """
+    Raised to indicate a local path falls outside the current batch root.
+    """
+    def __init__(self, path, base_path):
+        self.path = path
+        self.base_path = base_path
+
+    def __str__(self):
+        return f'{self.path} is not contained within {self.base_path}'
+
+
+class Asset:
     """
     Class representing a binary resource to be archived.
     """
@@ -20,7 +32,7 @@ class Asset():
         if self.local_path.startswith(batch_root):
             self.relpath = self.local_path[len(batch_root):]
         else:
-            raise Exception("local path is outside of batch root")
+            raise PathOutOfScopeException(path=self.local_path, base_path=batch_root)
 
     def calculate_md5(self):
         """

--- a/archiver/batch.py
+++ b/archiver/batch.py
@@ -27,6 +27,8 @@ class Batch():
         self.chunk_bytes = calculate_chunk_bytes(args.chunk)
         self.bucket = args.bucket
         self.root = os.path.abspath(args.root)
+        if not self.root.endswith('/'):
+            self.root += '/'
         self.storage_class = args.storage
 
         self.logdir = args.logs

--- a/bin/make_mapfile.sh
+++ b/bin/make_mapfile.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 ROOTDIR=$1
 OUTFILE=$2
 


### PR DESCRIPTION
* Ensure batch root ends with a "/"
* Raise an exception if the local path does not start with the batch root (i.e., it is outside the root)

Fixes: https://github.com/jwestgard/aws-archiver/issues/3