### PR TITLE
Change default chunksize from 5MB to 4GB

### DIFF
--- a/archiver/__main__.py
+++ b/archiver/__main__.py
@@ -54,7 +54,7 @@ def main():
                         '-c', '--chunk',
                         action='store',
                         help='Chunk size for multipart uploads',
-                        default='5MB'
+                        default='4GB'
     )
     deposit_parser.add_argument(
                         '-l', '--logs',


### PR DESCRIPTION
Two advantages to a larger size:
(1) files are limited to a max of 10,000 chunks so 4GB will allow larger files, and 
(2) all files less than the chunk size will use the md5 for AWS etag.